### PR TITLE
Add roll statistics tracking and server-wide stats commands

### DIFF
--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -9,6 +9,8 @@
 
     <ItemGroup>
       <PackageReference Include="Discord.Net" Version="3.19.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     </ItemGroup>
 
 </Project>

--- a/DiscordBot/Handlers/Constants.cs
+++ b/DiscordBot/Handlers/Constants.cs
@@ -16,4 +16,13 @@ public static class Constants
     public const string NewOpportunistCharacter = "new_opportunist_char";
     public const string NewPractitionerCharacter = "new_practitioner_char";
     public const string SubTypeOptionName = "sub_type";
+
+    public const string StatsOptionName = "stats";
+    public const string StatsSubDistribution = "distribution";
+    public const string StatsSubCrits = "crits";
+    public const string StatsSubTop = "top";
+    public const string StatsSubStreaks = "streaks";
+    public const string StatsSubHours = "hours";
+    public const string StatsDieOptionName = "die";
+    public const string StatsPublicOptionName = "public";
 }

--- a/DiscordBot/Handlers/DiceCommandHandler.cs
+++ b/DiscordBot/Handlers/DiceCommandHandler.cs
@@ -1,12 +1,13 @@
 using Discord.WebSocket;
 using DiscordBot.Models;
 using DiscordBot.Rollers.DiceRollers;
+using DiscordBot.Statistics;
 
 namespace DiscordBot.Handlers;
 
 public static class DiceCommandHandler
 {
-    public static async Task Handle(SocketSlashCommand command, bool hidden)
+    public static async Task Handle(SocketSlashCommand command, bool hidden, IRollRecorder recorder)
     {
         var userGlobalName = (command.User as SocketGuildUser)?.DisplayName;
 
@@ -14,12 +15,15 @@ public static class DiceCommandHandler
             ? command.Data.Options.First(x => x.Name == Constants.HiddenDiceOptionName).Value.ToString()
             : command.Data.Options.First(x => x.Name == Constants.DiceOptionName).Value.ToString();
 
-        var response = DiceRoller.ParseAndRollDice(new MessageDto
+        var result = DiceRoller.ParseAndRollDice(new MessageDto
         {
             Command = diceOption!,
             UserDisplayName = userGlobalName!,
             HiddenDice = hidden,
         });
-        await command.RespondAsync(response, ephemeral: hidden);
+        await command.RespondAsync(result.Message, ephemeral: hidden);
+
+        if (result.Rolls.Count > 0)
+            await recorder.RecordStandardRollsAsync(command, result.Rolls, result.Message);
     }
 }

--- a/DiscordBot/Handlers/DiscordCommandHandler.cs
+++ b/DiscordBot/Handlers/DiscordCommandHandler.cs
@@ -4,50 +4,62 @@ using Discord.WebSocket;
 using DiscordBot.Rollers.CharacterRollers;
 using DiscordBot.Rollers.CharacterRollers.Enums;
 using DiscordBot.Rollers.EffectRollers;
+using DiscordBot.Statistics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 
 namespace DiscordBot.Handlers;
 
-public class DiscordCommandHandler(string token)
+public class DiscordCommandHandler(
+    string token,
+    IRollRecorder recorder,
+    IDbContextFactory<StatisticsDbContext> statsContextFactory) : IHostedService
 {
     private readonly DiscordSocketClient _client = new(new DiscordSocketConfig
     {
         GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent,
     });
 
-    private static readonly Dictionary<string, Func<SocketSlashCommand, bool, Task>> DiceCommandHanders = new()
+    private readonly Dictionary<string, Func<SocketSlashCommand, bool, Task>> _diceCommandHanders = new()
     {
-        [Constants.RollOptionName] = (command, _) => DiceCommandHandler.Handle(command: command, hidden: false),
-        [Constants.RollOptionHiddenName] = (command, _) => DiceCommandHandler.Handle(command: command, hidden: true),
+        [Constants.RollOptionName] = (command, _) => DiceCommandHandler.Handle(command, hidden: false, recorder),
+        [Constants.RollOptionHiddenName] = (command, _) => DiceCommandHandler.Handle(command, hidden: true, recorder),
     };
 
-    private static readonly Dictionary<string, Func<SocketSlashCommand, Task>> EffectCommandHandlers = new()
+    private readonly Dictionary<string, Func<SocketSlashCommand, Task>> _effectCommandHandlers = new()
     {
-        [Constants.RollOptionDevilsLuckName] = EffectCommandHandler.Handle<DevilsLuckRoller>,
-        [Constants.RollOptionWoundName] = EffectCommandHandler.Handle<WoundRoller>,
-        [Constants.RollOptionMagicMisHapName] = EffectCommandHandler.Handle<MagicMisHapRoller>,
+        [Constants.RollOptionDevilsLuckName] = c => EffectCommandHandler.Handle<DevilsLuckRoller>(c, recorder),
+        [Constants.RollOptionWoundName] = c => EffectCommandHandler.Handle<WoundRoller>(c, recorder),
+        [Constants.RollOptionMagicMisHapName] = c => EffectCommandHandler.Handle<MagicMisHapRoller>(c, recorder),
     };
 
-    private static readonly Dictionary<string, Func<SocketSlashCommand, Task>> UtilityCommandHandlers = new()
+    private readonly Dictionary<string, Func<SocketSlashCommand, Task>> _utilityCommandHandlers = new()
     {
         [Constants.HelpOptionName] = HelpCommandHandler.Handle,
+        [Constants.StatsOptionName] = c => StatsCommandHandler.Handle(c, statsContextFactory),
     };
 
-    private static readonly Dictionary<string, Func<SocketSlashCommand, Task>> CharacterCommandHandlers = new()
+    private readonly Dictionary<string, Func<SocketSlashCommand, Task>> _characterCommandHandlers = new()
     {
-        [Constants.NewWitchCharacter] = NewCharacterCommandHandler.Roll<WitchCharacterRoller, WitchSubType>,
-        [Constants.NewBountyHunterCharacter] = NewCharacterCommandHandler.Roll<BountyHunterCharacterRoller, BountyHunterSubType>,
-        [Constants.NewMercenaryCharacter] = NewCharacterCommandHandler.Roll<MercenaryCharacterRoller, MercenarySubType>,
-        [Constants.NewOpportunistCharacter] = NewCharacterCommandHandler.Roll<OpportunistCharacterRoller, OpportunistSubType>,
-        [Constants.NewPractitionerCharacter] = NewCharacterCommandHandler.Roll<PractitionerCharacterRoller, PractitionerSubType>,
+        [Constants.NewWitchCharacter] = c => NewCharacterCommandHandler.Roll<WitchCharacterRoller, WitchSubType>(c, recorder),
+        [Constants.NewBountyHunterCharacter] = c => NewCharacterCommandHandler.Roll<BountyHunterCharacterRoller, BountyHunterSubType>(c, recorder),
+        [Constants.NewMercenaryCharacter] = c => NewCharacterCommandHandler.Roll<MercenaryCharacterRoller, MercenarySubType>(c, recorder),
+        [Constants.NewOpportunistCharacter] = c => NewCharacterCommandHandler.Roll<OpportunistCharacterRoller, OpportunistSubType>(c, recorder),
+        [Constants.NewPractitionerCharacter] = c => NewCharacterCommandHandler.Roll<PractitionerCharacterRoller, PractitionerSubType>(c, recorder),
     };
 
-    public async Task Start()
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        await _client.LoginAsync(TokenType.Bot, token);
-        await _client.StartAsync();
         _client.Ready += ReadyAsync;
         _client.SlashCommandExecuted += CommandHandler;
-        await Task.Delay(-1);
+        await _client.LoginAsync(TokenType.Bot, token);
+        await _client.StartAsync();
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _client.LogoutAsync();
+        await _client.StopAsync();
     }
 
     private async Task ReadyAsync()
@@ -123,20 +135,55 @@ public class DiscordCommandHandler(string token)
             new SlashCommandBuilder()
                 .WithName(Constants.HelpOptionName)
                 .WithDescription("Explanation and examples"),
+            new SlashCommandBuilder()
+                .WithName(Constants.StatsOptionName)
+                .WithDescription("View dice roll statistics for this server")
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName(Constants.StatsSubDistribution)
+                    .WithDescription("Show value distribution for a die type")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
+                    .AddOption(Constants.StatsDieOptionName, ApplicationCommandOptionType.Integer,
+                        "Die type, e.g. 20", isRequired: true, minValue: 2, maxValue: 100)
+                    .AddOption(Constants.StatsPublicOptionName, ApplicationCommandOptionType.Boolean,
+                        "Show to everyone in the channel (default: only you)", isRequired: false))
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName(Constants.StatsSubCrits)
+                    .WithDescription("Show nat 1 / nat 20 rates per user (d20)")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
+                    .AddOption(Constants.StatsPublicOptionName, ApplicationCommandOptionType.Boolean,
+                        "Show to everyone in the channel (default: only you)", isRequired: false))
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName(Constants.StatsSubTop)
+                    .WithDescription("Show roll counts per user")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
+                    .AddOption(Constants.StatsPublicOptionName, ApplicationCommandOptionType.Boolean,
+                        "Show to everyone in the channel (default: only you)", isRequired: false))
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName(Constants.StatsSubStreaks)
+                    .WithDescription("Show longest hot/cold d20 streaks per user")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
+                    .AddOption(Constants.StatsPublicOptionName, ApplicationCommandOptionType.Boolean,
+                        "Show to everyone in the channel (default: only you)", isRequired: false))
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName(Constants.StatsSubHours)
+                    .WithDescription("Show roll activity by hour of day (UTC)")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
+                    .AddOption(Constants.StatsPublicOptionName, ApplicationCommandOptionType.Boolean,
+                        "Show to everyone in the channel (default: only you)", isRequired: false)),
         ];
     }
 
-    private static async Task CommandHandler(SocketSlashCommand command)
+    private async Task CommandHandler(SocketSlashCommand command)
     {
         var commandHandler = command.Data.Name switch
         {
-            var name when CharacterCommandHandlers.TryGetValue(name, out var characterHandler)
+            var name when _characterCommandHandlers.TryGetValue(name, out var characterHandler)
                 => characterHandler(command),
-            var name when EffectCommandHandlers.TryGetValue(name, out var effectHandler)
+            var name when _effectCommandHandlers.TryGetValue(name, out var effectHandler)
                 => effectHandler(command),
-            var name when DiceCommandHanders.TryGetValue(name, out var diceHandler)
+            var name when _diceCommandHanders.TryGetValue(name, out var diceHandler)
                 => diceHandler(command, name == Constants.RollOptionHiddenName),
-            var name when UtilityCommandHandlers.TryGetValue(name, out var utilityHandler)
+            var name when _utilityCommandHandlers.TryGetValue(name, out var utilityHandler)
                 => utilityHandler(command),
             _ => command.RespondAsync(ErrorMessages.FallbackErrorMessage, ephemeral: true),
         };

--- a/DiscordBot/Handlers/EffectCommandHandler.cs
+++ b/DiscordBot/Handlers/EffectCommandHandler.cs
@@ -1,13 +1,16 @@
 using Discord.WebSocket;
 using DiscordBot.Rollers.EffectRollers;
+using DiscordBot.Statistics;
 
 namespace DiscordBot.Handlers;
 
 public abstract class EffectCommandHandler
 {
-    public static async Task Handle<TEffectRoller>(SocketSlashCommand command) where TEffectRoller : IEffectRoller
+    public static async Task Handle<TEffectRoller>(SocketSlashCommand command, IRollRecorder recorder)
+        where TEffectRoller : IEffectRoller
     {
         var effect = TEffectRoller.Roll();
         await command.RespondAsync(effect, ephemeral: false);
+        await recorder.RecordEffectRollAsync(command, typeof(TEffectRoller).Name, effect);
     }
 }

--- a/DiscordBot/Handlers/NewCharacterCommandHandler.cs
+++ b/DiscordBot/Handlers/NewCharacterCommandHandler.cs
@@ -1,16 +1,18 @@
 using Discord.WebSocket;
 using DiscordBot.Parsers;
 using DiscordBot.Rollers.CharacterRollers;
+using DiscordBot.Statistics;
 
 namespace DiscordBot.Handlers;
 
 public abstract class NewCharacterCommandHandler
 {
-    public static async Task Roll<TCharacterRoller, TKSubType>(SocketSlashCommand command)
+    public static async Task Roll<TCharacterRoller, TKSubType>(SocketSlashCommand command, IRollRecorder recorder)
         where TCharacterRoller : ICharacterRoller<TKSubType> where TKSubType : Enum
     {
         var subType = CharacterSubTypeParser.Parse<TKSubType>(command);
         var character = TCharacterRoller.Roll(subType);
         await command.RespondAsync(character, ephemeral: false);
+        await recorder.RecordCharacterRollAsync(command, $"{typeof(TCharacterRoller).Name}/{subType}", character);
     }
 }

--- a/DiscordBot/Handlers/StatsCommandHandler.cs
+++ b/DiscordBot/Handlers/StatsCommandHandler.cs
@@ -1,0 +1,286 @@
+using System.Text;
+using Discord.WebSocket;
+using DiscordBot.Statistics;
+using DiscordBot.Statistics.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordBot.Handlers;
+
+public static class StatsCommandHandler
+{
+    private const int BarWidth = 15;
+    private const char BarChar = '█';
+
+    public static async Task Handle(SocketSlashCommand command, IDbContextFactory<StatisticsDbContext> contextFactory)
+    {
+        if (command.GuildId is not { } guildId)
+        {
+            await command.RespondAsync("📊 Stats are only available inside a server.", ephemeral: true);
+            return;
+        }
+
+        var sub = command.Data.Options.First();
+        var subOptions = sub.Options;
+        var makePublic = subOptions.FirstOrDefault(o => o.Name == Constants.StatsPublicOptionName)?.Value as bool? ?? false;
+
+        var response = sub.Name switch
+        {
+            Constants.StatsSubDistribution => await BuildDistribution(contextFactory, guildId,
+                (long)(subOptions.First(o => o.Name == Constants.StatsDieOptionName).Value)),
+            Constants.StatsSubCrits => await BuildCrits(contextFactory, guildId),
+            Constants.StatsSubTop => await BuildTop(contextFactory, guildId),
+            Constants.StatsSubStreaks => await BuildStreaks(contextFactory, guildId),
+            Constants.StatsSubHours => await BuildHours(contextFactory, guildId),
+            _ => "📊 Unknown stats subcommand.",
+        };
+
+        await command.RespondAsync(Trim(response), ephemeral: !makePublic);
+    }
+
+    private static async Task<string> BuildDistribution(
+        IDbContextFactory<StatisticsDbContext> contextFactory, ulong guildId, long dieType)
+    {
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+
+        var rows = await (
+            from d in ctx.RollDice
+            join r in ctx.Rolls on d.RollId equals r.Id
+            where r.GuildId == guildId && d.DieType == (int)dieType
+            group d by d.Value into g
+            select new { Value = g.Key, Count = g.Count() }).ToListAsync();
+
+        var total = rows.Sum(r => r.Count);
+        if (total == 0)
+            return $"🎲 No d{dieType} rolls recorded yet on this server.";
+
+        var byValue = rows.ToDictionary(r => r.Value, r => r.Count);
+        var max = rows.Max(r => r.Count);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("```");
+        sb.AppendLine($"🎲 d{dieType} Distribution — this server");
+        sb.AppendLine($"Total rolls: {total}");
+        sb.AppendLine();
+
+        for (var v = 1; v <= dieType; v++)
+        {
+            var count = byValue.GetValueOrDefault((int)v, 0);
+            var bar = new string(BarChar, ScaleBar(count, max));
+            var pct = (double)count / total * 100;
+            sb.AppendLine($"{v,3}: {bar,-BarWidth} {count} ({pct:0.0}%)");
+        }
+
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static async Task<string> BuildCrits(
+        IDbContextFactory<StatisticsDbContext> contextFactory, ulong guildId)
+    {
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+
+        var rows = await (
+            from d in ctx.RollDice
+            join r in ctx.Rolls on d.RollId equals r.Id
+            where r.GuildId == guildId && d.DieType == 20
+            select new { r.UserId, d.Value }).ToListAsync();
+
+        if (rows.Count == 0)
+            return "🎯 No d20 rolls recorded yet on this server.";
+
+        var names = await GetLatestNames(ctx, guildId);
+
+        var perUser = rows
+            .GroupBy(x => x.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                Total = g.Count(),
+                Nat20 = g.Count(x => x.Value == 20),
+                Nat1 = g.Count(x => x.Value == 1),
+            })
+            .OrderByDescending(x => x.Total)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("```");
+        sb.AppendLine("🎯 Critical Rolls — d20 (this server)");
+        sb.AppendLine();
+
+        foreach (var u in perUser)
+        {
+            var name = SafeName(names.GetValueOrDefault(u.UserId, u.UserId.ToString()));
+            var nat20Pct = (double)u.Nat20 / u.Total * 100;
+            var nat1Pct = (double)u.Nat1 / u.Total * 100;
+            sb.AppendLine($"{name}");
+            sb.AppendLine($"  rolls: {u.Total}  nat20: {u.Nat20} ({nat20Pct:0.0}%)  nat1: {u.Nat1} ({nat1Pct:0.0}%)");
+        }
+
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static async Task<string> BuildTop(
+        IDbContextFactory<StatisticsDbContext> contextFactory, ulong guildId)
+    {
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+
+        var rolls = await ctx.Rolls
+            .Where(r => r.GuildId == guildId)
+            .Select(r => new { r.UserId, r.RollType })
+            .ToListAsync();
+
+        if (rolls.Count == 0)
+            return "🏆 No rolls recorded yet on this server.";
+
+        var names = await GetLatestNames(ctx, guildId);
+
+        var leaderboard = rolls
+            .GroupBy(x => x.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                Total = g.Count(),
+                Standard = g.Count(x => x.RollType == RollType.Standard),
+                Effect = g.Count(x => x.RollType == RollType.Effect),
+                Character = g.Count(x => x.RollType == RollType.Character),
+            })
+            .OrderByDescending(x => x.Total)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("```");
+        sb.AppendLine("🏆 Roll Leaderboard — this server");
+        sb.AppendLine();
+
+        for (var i = 0; i < leaderboard.Count; i++)
+        {
+            var l = leaderboard[i];
+            var name = SafeName(names.GetValueOrDefault(l.UserId, l.UserId.ToString()));
+            sb.AppendLine($"{i + 1,2}. {name}");
+            sb.AppendLine($"    total: {l.Total}  standard: {l.Standard}  effect: {l.Effect}  char: {l.Character}");
+        }
+
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static async Task<string> BuildStreaks(
+        IDbContextFactory<StatisticsDbContext> contextFactory, ulong guildId)
+    {
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+
+        var rolls = await (
+            from d in ctx.RollDice
+            join r in ctx.Rolls on d.RollId equals r.Id
+            where r.GuildId == guildId && d.DieType == 20
+            orderby r.Timestamp, d.Position
+            select new { r.UserId, d.Value }).ToListAsync();
+
+        if (rolls.Count == 0)
+            return "🔥 No d20 rolls recorded yet on this server.";
+
+        var names = await GetLatestNames(ctx, guildId);
+
+        var perUser = rolls
+            .GroupBy(x => x.UserId)
+            .Select(g => new
+            {
+                UserId = g.Key,
+                Hot = LongestRun(g.Select(x => x.Value), v => v >= 11),
+                Cold = LongestRun(g.Select(x => x.Value), v => v <= 10),
+            })
+            .OrderByDescending(x => Math.Max(x.Hot, x.Cold))
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("```");
+        sb.AppendLine("🔥 d20 Streaks — this server (consecutive ≥11 hot, ≤10 cold)");
+        sb.AppendLine();
+
+        foreach (var u in perUser)
+        {
+            var name = SafeName(names.GetValueOrDefault(u.UserId, u.UserId.ToString()));
+            sb.AppendLine($"{name}");
+            sb.AppendLine($"    hot: {u.Hot}  cold: {u.Cold}");
+        }
+
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static async Task<string> BuildHours(
+        IDbContextFactory<StatisticsDbContext> contextFactory, ulong guildId)
+    {
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+
+        var times = await ctx.Rolls
+            .Where(r => r.GuildId == guildId)
+            .Select(r => r.Timestamp)
+            .ToListAsync();
+
+        if (times.Count == 0)
+            return "⏰ No rolls recorded yet on this server.";
+
+        var byHour = times
+            .GroupBy(t => t.Hour)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var max = byHour.Values.Max();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("```");
+        sb.AppendLine("⏰ Activity by Hour (UTC) — this server");
+        sb.AppendLine($"Total rolls: {times.Count}");
+        sb.AppendLine();
+
+        for (var h = 0; h < 24; h++)
+        {
+            var count = byHour.GetValueOrDefault(h, 0);
+            var bar = new string(BarChar, ScaleBar(count, max));
+            sb.AppendLine($"{h:00}: {bar,-BarWidth} {count}");
+        }
+
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static async Task<Dictionary<ulong, string>> GetLatestNames(StatisticsDbContext ctx, ulong guildId)
+    {
+        var pairs = await ctx.Rolls
+            .Where(r => r.GuildId == guildId)
+            .Select(r => new { r.UserId, r.UserDisplayName, r.Timestamp })
+            .ToListAsync();
+
+        return pairs
+            .GroupBy(p => p.UserId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.Timestamp).First().UserDisplayName);
+    }
+
+    private static int LongestRun(IEnumerable<int> values, Func<int, bool> predicate)
+    {
+        var longest = 0;
+        var current = 0;
+        foreach (var v in values)
+        {
+            if (predicate(v))
+            {
+                current++;
+                if (current > longest) longest = current;
+            }
+            else
+            {
+                current = 0;
+            }
+        }
+        return longest;
+    }
+
+    private static int ScaleBar(int count, int max) =>
+        max == 0 ? 0 : (int)Math.Round((double)count / max * BarWidth);
+
+    private static string SafeName(string name) => name.Replace("`", "'");
+
+    private static string Trim(string text) =>
+        text.Length <= 1900 ? text : text[..1900] + "\n…(truncated)\n```";
+}

--- a/DiscordBot/Program.cs
+++ b/DiscordBot/Program.cs
@@ -1,9 +1,33 @@
-﻿using DiscordBot.Handlers;
+using DiscordBot.Handlers;
+using DiscordBot.Statistics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 var discordBotToken = Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN");
-
 ArgumentException.ThrowIfNullOrEmpty(discordBotToken);
 
-var discordCommandHandler = new DiscordCommandHandler(discordBotToken);
+var dbPath = Environment.GetEnvironmentVariable("DICE_BOT_DB_PATH") ?? "dicestats.db";
 
-await discordCommandHandler.Start();
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddDbContextFactory<StatisticsDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+
+builder.Services.AddSingleton<IRollRecorder, RollRecorder>();
+builder.Services.AddHostedService(sp =>
+    new DiscordCommandHandler(
+        discordBotToken,
+        sp.GetRequiredService<IRollRecorder>(),
+        sp.GetRequiredService<IDbContextFactory<StatisticsDbContext>>()));
+
+var host = builder.Build();
+
+await using (var scope = host.Services.CreateAsyncScope())
+{
+    var contextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<StatisticsDbContext>>();
+    await using var ctx = await contextFactory.CreateDbContextAsync();
+    await ctx.Database.EnsureCreatedAsync();
+}
+
+await host.RunAsync();

--- a/DiscordBot/Rollers/DiceRollers/DiceRollResult.cs
+++ b/DiscordBot/Rollers/DiceRollers/DiceRollResult.cs
@@ -1,0 +1,5 @@
+using DiscordBot.Models;
+
+namespace DiscordBot.Rollers.DiceRollers;
+
+public record DiceRollResult(string Message, IReadOnlyList<RollDiceCommand> Rolls);

--- a/DiscordBot/Rollers/DiceRollers/DiceRoller.cs
+++ b/DiscordBot/Rollers/DiceRollers/DiceRoller.cs
@@ -7,7 +7,7 @@ namespace DiscordBot.Rollers.DiceRollers;
 
 public static class DiceRoller
 {
-    public static string ParseAndRollDice(MessageDto messageDto)
+    public static DiceRollResult ParseAndRollDice(MessageDto messageDto)
     {
         try
         {
@@ -17,7 +17,7 @@ public static class DiceRoller
             foreach (var rollDiceCommand in rollDiceCommands)
             {
                 if (rollDiceCommand.ValidCommand)
-                    return ErrorMessages.InvalidRollCommand;
+                    return new DiceRollResult(ErrorMessages.InvalidRollCommand, []);
 
                 // Roll the dice
                 for (var i = 0; i < rollDiceCommand.DiceCount; i++)
@@ -28,11 +28,11 @@ public static class DiceRoller
                 sb.Append(DiceRollerMessages.GetResultMessage(rollDiceCommand, messageDto.HiddenDice));
             }
 
-            return sb.ToString();
+            return new DiceRollResult(sb.ToString(), rollDiceCommands);
         }
         catch (Exception)
         {
-            return ErrorMessages.InvalidRollCommand;
+            return new DiceRollResult(ErrorMessages.InvalidRollCommand, []);
         }
     }
 }

--- a/DiscordBot/Statistics/IRollRecorder.cs
+++ b/DiscordBot/Statistics/IRollRecorder.cs
@@ -1,0 +1,11 @@
+using Discord.WebSocket;
+using DiscordBot.Models;
+
+namespace DiscordBot.Statistics;
+
+public interface IRollRecorder
+{
+    Task RecordStandardRollsAsync(SocketSlashCommand command, IReadOnlyList<RollDiceCommand> rolls, string resultText);
+    Task RecordEffectRollAsync(SocketSlashCommand command, string subType, string resultText);
+    Task RecordCharacterRollAsync(SocketSlashCommand command, string subType, string resultText);
+}

--- a/DiscordBot/Statistics/Models/Roll.cs
+++ b/DiscordBot/Statistics/Models/Roll.cs
@@ -1,0 +1,19 @@
+namespace DiscordBot.Statistics.Models;
+
+public class Roll
+{
+    public long Id { get; set; }
+    public ulong? GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong UserId { get; set; }
+    public required string UserDisplayName { get; set; }
+    public RollType RollType { get; set; }
+    public string? RollSubType { get; set; }
+    public required string Command { get; set; }
+    public int? Total { get; set; }
+    public int? Modifier { get; set; }
+    public required string ResultText { get; set; }
+    public DateTime Timestamp { get; set; }
+
+    public List<RollDie> Dice { get; set; } = [];
+}

--- a/DiscordBot/Statistics/Models/RollDie.cs
+++ b/DiscordBot/Statistics/Models/RollDie.cs
@@ -1,0 +1,11 @@
+namespace DiscordBot.Statistics.Models;
+
+public class RollDie
+{
+    public long Id { get; set; }
+    public long RollId { get; set; }
+    public int DieType { get; set; }
+    public int Value { get; set; }
+    public bool Kept { get; set; }
+    public int Position { get; set; }
+}

--- a/DiscordBot/Statistics/Models/RollType.cs
+++ b/DiscordBot/Statistics/Models/RollType.cs
@@ -1,0 +1,8 @@
+namespace DiscordBot.Statistics.Models;
+
+public enum RollType
+{
+    Standard,
+    Effect,
+    Character,
+}

--- a/DiscordBot/Statistics/RollRecorder.cs
+++ b/DiscordBot/Statistics/RollRecorder.cs
@@ -1,0 +1,122 @@
+using Discord.WebSocket;
+using DiscordBot.Models;
+using DiscordBot.Statistics.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DiscordBot.Statistics;
+
+public class RollRecorder(
+    IDbContextFactory<StatisticsDbContext> contextFactory,
+    ILogger<RollRecorder> logger) : IRollRecorder
+{
+    public async Task RecordStandardRollsAsync(
+        SocketSlashCommand command,
+        IReadOnlyList<RollDiceCommand> rolls,
+        string resultText)
+    {
+        try
+        {
+            var (userId, displayName, guildId, channelId) = ExtractContext(command);
+            var timestamp = DateTime.UtcNow;
+
+            await using var context = await contextFactory.CreateDbContextAsync();
+
+            foreach (var rollCommand in rolls)
+            {
+                var keptIndices = GetKeptIndices(rollCommand);
+                var roll = new Roll
+                {
+                    GuildId = guildId,
+                    ChannelId = channelId,
+                    UserId = userId,
+                    UserDisplayName = displayName,
+                    RollType = RollType.Standard,
+                    RollSubType = null,
+                    Command = rollCommand.Command,
+                    Total = rollCommand.GetTotal(),
+                    Modifier = rollCommand.Modifier,
+                    ResultText = resultText,
+                    Timestamp = timestamp,
+                    Dice = rollCommand.Rolls
+                        .Select((value, index) => new RollDie
+                        {
+                            DieType = rollCommand.DiceType,
+                            Value = value,
+                            Kept = keptIndices.Contains(index),
+                            Position = index,
+                        })
+                        .ToList(),
+                };
+                context.Rolls.Add(roll);
+            }
+
+            await context.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to record standard roll(s) for user {User}", command.User.Username);
+        }
+    }
+
+    public Task RecordEffectRollAsync(SocketSlashCommand command, string subType, string resultText) =>
+        RecordSimpleAsync(command, RollType.Effect, subType, resultText);
+
+    public Task RecordCharacterRollAsync(SocketSlashCommand command, string subType, string resultText) =>
+        RecordSimpleAsync(command, RollType.Character, subType, resultText);
+
+    private async Task RecordSimpleAsync(
+        SocketSlashCommand command,
+        RollType rollType,
+        string subType,
+        string resultText)
+    {
+        try
+        {
+            var (userId, displayName, guildId, channelId) = ExtractContext(command);
+
+            await using var context = await contextFactory.CreateDbContextAsync();
+            context.Rolls.Add(new Roll
+            {
+                GuildId = guildId,
+                ChannelId = channelId,
+                UserId = userId,
+                UserDisplayName = displayName,
+                RollType = rollType,
+                RollSubType = subType,
+                Command = command.Data.Name,
+                Total = null,
+                Modifier = null,
+                ResultText = resultText,
+                Timestamp = DateTime.UtcNow,
+            });
+            await context.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to record {RollType}/{SubType} for user {User}",
+                rollType, subType, command.User.Username);
+        }
+    }
+
+    private static (ulong UserId, string DisplayName, ulong? GuildId, ulong ChannelId) ExtractContext(
+        SocketSlashCommand command)
+    {
+        var guildUser = command.User as SocketGuildUser;
+        var displayName = guildUser?.DisplayName ?? command.User.GlobalName ?? command.User.Username;
+        var guildId = guildUser?.Guild.Id;
+        return (command.User.Id, displayName, guildId, command.ChannelId ?? 0UL);
+    }
+
+    private static HashSet<int> GetKeptIndices(RollDiceCommand rollCommand)
+    {
+        var ordered = rollCommand.Rolls
+            .Select((value, index) => (value, index));
+
+        var kept = rollCommand.KeepHigh
+            ? ordered.OrderByDescending(t => t.value).Take(rollCommand.DicesToKeep)
+            : ordered.OrderBy(t => t.value).Take(rollCommand.DicesToKeep);
+
+        return kept.Select(t => t.index).ToHashSet();
+    }
+}

--- a/DiscordBot/Statistics/StatisticsDbContext.cs
+++ b/DiscordBot/Statistics/StatisticsDbContext.cs
@@ -1,0 +1,32 @@
+using DiscordBot.Statistics.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DiscordBot.Statistics;
+
+public class StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : DbContext(options)
+{
+    public DbSet<Roll> Rolls => Set<Roll>();
+    public DbSet<RollDie> RollDice => Set<RollDie>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Roll>(roll =>
+        {
+            roll.HasKey(r => r.Id);
+            roll.Property(r => r.RollType).HasConversion<string>();
+            roll.HasIndex(r => r.UserId);
+            roll.HasIndex(r => r.GuildId);
+            roll.HasIndex(r => r.Timestamp);
+            roll.HasMany(r => r.Dice)
+                .WithOne()
+                .HasForeignKey(d => d.RollId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<RollDie>(die =>
+        {
+            die.HasKey(d => d.Id);
+            die.HasIndex(d => d.DieType);
+        });
+    }
+}


### PR DESCRIPTION
- Implement `RollRecorder` to log roll data to a SQLite database.
- Add models for rolls and dice (`Roll`, `RollDie`, `RollType`) and configure EF Core DbContext.
- Extend dice, character, and effect command handlers to record rolls using `IRollRecorder`.
- Introduce `StatsCommandHandler` to provide server-level stats (distributions, crits, top users, streaks, hourly activity).
- Refactor `DiscordCommandHandler` to support stats-related commands.
- Update dependencies to include EF Core and SQLite packages.